### PR TITLE
Handle timezones for datetime fields

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -36,4 +36,5 @@ generally made django-autoslug better:
 * Julien Dubiel
 * Tony Shtarev
 * Éloi Rivard
+* Peter Baumgartner
 * Your Name Here ;)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Handle timezones for datetime fields

--- a/autoslug/tests/models.py
+++ b/autoslug/tests/models.py
@@ -1,4 +1,5 @@
-from django.db.models import Model, CharField, DateField, BooleanField, ForeignKey, Manager
+from django.db.models import (Model, CharField, DateField, DateTimeField,
+                              BooleanField, ForeignKey, Manager)
 
 
 # this app
@@ -28,7 +29,7 @@ class ModelWithUniqueSlugDate(Model):
 
 
 class ModelWithUniqueSlugDay(Model):  # same as ...Date, just more explicit
-    date = DateField()
+    date = DateTimeField()
     slug = AutoSlugField(unique_with='date__day')
 
 

--- a/autoslug/tests/tests.py
+++ b/autoslug/tests/tests.py
@@ -17,6 +17,8 @@ import unittest
 # django
 from django.db import IntegrityError
 from django.test import TestCase
+from django.test import override_settings
+from django.utils.timezone import make_aware
 
 # this package
 from .models import *
@@ -75,6 +77,24 @@ class AutoSlugFieldTestCase(TestCase):
         a = ModelWithUniqueSlugDate(slug='test', date=datetime.date(2009, 9,  9))
         b = ModelWithUniqueSlugDate(slug='test', date=datetime.date(2009, 9,  9))
         c = ModelWithUniqueSlugDate(slug='test', date=datetime.date(2009, 9, 10))
+        for m in a,b,c:
+            m.save()
+        assert a.slug == u'test'
+        assert b.slug == u'test-2'
+        assert c.slug == u'test'
+
+    @unittest.skipIf('PyPy' in sys.version, PYPY_DATE_FUNC_SKIP_MSG)
+    @override_settings(USE_TZ=True, DEFAULT_TIMEZONE='US/Pacific')
+    def test_unique_slug_date_with_tz(self):
+        try:
+            import pytz
+        except ImportError:
+            raise unittest.SkipTest("pytz is not available, skipping test")
+        same_day = make_aware(datetime.datetime(2009, 9,  9, 1), pytz.UTC)
+        different_day = make_aware(datetime.datetime(2009, 9, 10, 1), pytz.UTC)
+        a = ModelWithUniqueSlugDate(slug='test', date=same_day)
+        b = ModelWithUniqueSlugDate(slug='test', date=same_day)
+        c = ModelWithUniqueSlugDate(slug='test', date=different_day)
         for m in a,b,c:
             m.save()
         assert a.slug == u'test'

--- a/autoslug/utils.py
+++ b/autoslug/utils.py
@@ -10,10 +10,12 @@
 #
 
 # django
+import datetime
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import ForeignKey
 from django.db.models.fields import FieldDoesNotExist, DateField
 from django.template.defaultfilters import slugify as django_slugify
+from django.utils.timezone import localtime, is_aware
 
 try:
     # i18n-friendly approach
@@ -128,6 +130,8 @@ def get_uniqueness_lookups(field, instance, unique_with):
                              % (instance._meta.object_name, field.name,
                                 instance._meta.object_name, field_name,
                                 field.name))
+        if isinstance(value, datetime.datetime) and is_aware(value):
+            value = localtime(value)
         if isinstance(other_field, DateField):    # DateTimeField is a DateField subclass
             inner_lookup = inner_lookup or 'day'
 

--- a/autoslug/utils.py
+++ b/autoslug/utils.py
@@ -118,7 +118,12 @@ def get_uniqueness_lookups(field, instance, unique_with):
         value = getattr(instance, field_name)
         if not value:
             if other_field.blank:
-                field_object, model, direct, m2m = instance._meta.get_field_by_name(field_name)
+                try:
+                    field_object = instance._meta.get_field(field_name)
+                # For Django < 1.10
+                except AttributeError:
+                    field_object, model, direct, m2m = instance._meta.get_field_by_name(
+                        field_name)
                 if isinstance(field_object, ForeignKey):
                     lookup = '%s__isnull' % field_name
                     yield lookup, True

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -3,3 +3,6 @@ django-modeltranslation>=0.10
 # l10n
 pytils>=0.2
 Unidecode>=0.04
+
+# timezones
+pytz


### PR DESCRIPTION
Timezone information is lost when splitting up dates into `year`, `month`, and `day` lookups. This makes sure a timezone aware datetime gets converted to the correct timezone before splitting up to check for duplicate slugs.
