### PR TITLE
Fix assertion error on empty slug

### DIFF
--- a/autoslug/fields.py
+++ b/autoslug/fields.py
@@ -270,18 +270,16 @@ class AutoSlugField(SlugField):
                 print('Failed to populate slug %s.%s from %s' % \
                       (instance._meta.object_name, self.name, self.populate_from))
 
+        slug = None
         if value:
             slug = self.slugify(value)
-        else:
+        if not slug:
             slug = None
 
             if not self.blank:
                 slug = instance._meta.model_name
             elif not self.null:
                 slug = ''
-
-        if not self.blank:
-            assert slug, 'slug is defined before trying to ensure uniqueness'
 
         if slug:
             slug = utils.crop_slug(self, slug)

--- a/autoslug/tests/tests.py
+++ b/autoslug/tests/tests.py
@@ -139,6 +139,10 @@ class AutoSlugFieldTestCase(TestCase):
         assert a.slug is not None
         assert a.slug == ''
 
+    def test_empty_slugify(self):
+        a = ModelWithUniqueSlug.objects.create(name='?')
+        assert a.slug
+
     def test_callable(self):
         a = ModelWithCallable.objects.create(name='larch')
         assert a.slug == u'the-larch'


### PR DESCRIPTION
Without this fix, using names which `slugify` renders to an empty string (like `?` in the test included with this PR) will trigger a strange assertion.