### PR TITLE
Fix for Django 2.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,14 +70,14 @@ More complex example:
 
 .. code-block:: python
 
-    from django.db.models import CharField, DateField, ForeignKey, Model
+    from django.db.models import CharField, DateField, ForeignKey, Model, CASCADE
     from django.contrib.auth.models import User
     from autoslug import AutoSlugField
 
     class Article(Model):
         title = CharField(max_length=200)
         pub_date = DateField(auto_now_add=True)
-        author = ForeignKey(User)
+        author = ForeignKey(User, on_delete=CASCADE)
         slug = AutoSlugField(populate_from=lambda instance: instance.title,
                              unique_with=['author__name', 'pub_date__month'],
                              slugify=lambda value: value.replace(' ','-'))

--- a/autoslug/settings.py
+++ b/autoslug/settings.py
@@ -58,7 +58,7 @@ Django settings that affect django-autoslug:
 
 """
 from django.conf import settings
-from django.core.urlresolvers import get_callable
+from django.urls import get_callable
 
 # use custom slugifying function if any
 slugify_function_path = getattr(settings, 'AUTOSLUG_SLUGIFY_FUNCTION', 'autoslug.utils.slugify')

--- a/requirements/basic.txt
+++ b/requirements/basic.txt
@@ -1,2 +1,1 @@
-#python>=2.7
-django>=1.7
+coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -16,3 +16,4 @@ deps =
     django2.0: Django>=2.0
 commands =
     coverage run --source=autoslug  run_tests.py []
+    coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,18 @@
 [tox]
 #envlist = py27, py35, pypy, pypy3
-envlist = py27, py35, pypy
+envlist =
+    py27-django1.x,
+    py35-django{2.0,1.x},
+    pypy-django1.x
 indexserver=
 default = http://pypi.python.org/simple
 testrun = http://pypi.testrun.org
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
-deps     =
-    coveralls
+deps =
     -r{toxinidir}/requirements/testing.txt
+    django1.x: Django>=1.7,<2.0
+    django2.0: Django>=2.0
 commands =
     coverage run --source=autoslug  run_tests.py []
-    coveralls


### PR DESCRIPTION
One import had to change from the deprecated old location to the new Django 2.0 location.

I updated the docs to include the now-required `on_delete` on a ForeignKey.

And here's a cute animal picture for you!

![muskoxen](http://www.acuteaday.com/blog/wp-content/uploads/2012/12/muskox-resting-with-calf.jpg)