### PR TITLE
Adding support for Django >= 2.0

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,4 +32,5 @@ generally made django-autoslug better:
 * Julien Dubiel
 * Tony Shtarev
 * Éloi Rivard
+* Mahmoud Ahmed
 * Your Name Here ;)

--- a/autoslug/settings.py
+++ b/autoslug/settings.py
@@ -58,7 +58,10 @@ Django settings that affect django-autoslug:
 
 """
 from django.conf import settings
-from django.core.urlresolvers import get_callable
+try:
+    from django.core.urlresolvers import get_callable
+except ImportError:
+    from django.urls.resolvers import get_callable
 
 # use custom slugifying function if any
 slugify_function_path = getattr(settings, 'AUTOSLUG_SLUGIFY_FUNCTION', 'autoslug.utils.slugify')


### PR DESCRIPTION
In Django 2.0 The `django.core.urlresolvers` module is removed in favor of its new location,` django.urls`.