### PR TITLE
Import 'FieldDoesNotExist' from 'django.core.exceptions'

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,4 +38,5 @@ generally made django-autoslug better:
 * Éloi Rivard
 * Peter Baumgartner
 * Jernej Kos
+* `Sutrisno Efendi <http://github.com/kangfend>`_
 * Your Name Here ;)

--- a/autoslug/utils.py
+++ b/autoslug/utils.py
@@ -12,9 +12,9 @@
 
 # django
 import datetime
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, FieldDoesNotExist
 from django.db.models import ForeignKey
-from django.db.models.fields import FieldDoesNotExist, DateField
+from django.db.models.fields import DateField
 from django.template.defaultfilters import slugify as django_slugify
 from django.utils.timezone import localtime, is_aware
 


### PR DESCRIPTION
The compatibility import of django.core.exceptions.FieldDoesNotExist in django.db.models.fields will be removed in Django 3.1.x https://docs.djangoproject.com/en/3.1/releases/3.1/#id1